### PR TITLE
GH-28 Added listJobs to ssh and Zosmf messaging

### DIFF
--- a/src/main/kotlin/org/zowe/kotlinsdk/core/jes/api/messaging/ListJobsResponse.kt
+++ b/src/main/kotlin/org/zowe/kotlinsdk/core/jes/api/messaging/ListJobsResponse.kt
@@ -10,13 +10,13 @@
 
 package org.zowe.kotlinsdk.core.jes.api.messaging
 
-import org.zowe.kotlinsdk.core.Request
+import org.zowe.kotlinsdk.core.Response
 import org.zowe.kotlinsdk.core.jes.data.JobItem
 
 /**
  * Represents a basic response of the list jobs request
  * @param jobs the list of [JobItem] returned by a client
  */
-interface ListJobsResponse : Request {
+interface ListJobsResponse : Response {
   val jobs: List<JobItem>
 }

--- a/src/main/kotlin/org/zowe/kotlinsdk/providers/zowe/openssh/jes/messaging/SshListJobsResponse.kt
+++ b/src/main/kotlin/org/zowe/kotlinsdk/providers/zowe/openssh/jes/messaging/SshListJobsResponse.kt
@@ -10,26 +10,102 @@
 
 package org.zowe.kotlinsdk.providers.zowe.openssh.jes.messaging
 
-import org.zowe.kotlinsdk.core.Response
 import org.zowe.kotlinsdk.core.Status
+import org.zowe.kotlinsdk.core.StatusType
 import org.zowe.kotlinsdk.core.jes.api.messaging.ListJobsResponse
 import org.zowe.kotlinsdk.providers.zowe.SshCmdResponse
 import org.zowe.kotlinsdk.providers.zowe.SshResponse
+import org.zowe.kotlinsdk.providers.zowe.openssh.jes.definitions.SshJobExecData
 import org.zowe.kotlinsdk.providers.zowe.openssh.jes.definitions.SshJobItem
+import org.zowe.kotlinsdk.providers.zowe.openssh.jes.definitions.SshJobStepData
+import org.zowe.kotlinsdk.providers.zowe.openssh.jes.extractJobValue
 
-// TODO: doc
-// TODO: implement
+/**
+ * List jobs SSH command response.
+ * Parses the multi-job SSH output and produces a list of [SshJobItem] instances.
+ * @property status the status of the SSH command execution
+ * @property jobs the list of parsed [SshJobItem] from the command output
+ */
 class SshListJobsResponse(cmdResponse: SshCmdResponse) : SshResponse, ListJobsResponse {
-  override val status: Status
-    get() = TODO("Not yet implemented")
-  override val jobs: List<SshJobItem>
-    get() = TODO("Not yet implemented")
+  override val status: Status = SshGetJobStatus(cmdResponse)
 
-  override suspend fun produceResponseObject(clientResponse: Any): Response {
-    TODO("Not yet implemented")
+  // Queue-to-status mapping, same as in SshGetJobResponse
+  private val inputStatusQueues = listOf("CONVERSION", "SETUP")
+  private val activeStatusQueues = listOf("EXECUTION", "INPUT")
+  private val outputStatusQueues = listOf("PRINT", "OUTPUT", "XMITTER", "RECEIVE", "SPIN", "PURGE")
+
+  /**
+   * Get the job status by the queue the job is placed in
+   * @param queue the queue (from ISFEXEC ST) name the job is currently in
+   * @return the [SshJobItem.SshJobStatus] or null if the queue is "UNKNOWN"
+   */
+  private fun getJobStatusFromQueue(queue: String): SshJobItem.SshJobStatus? {
+    val indepQueue = queue.replace(" (JES3)", "")
+    return when {
+      inputStatusQueues.contains(indepQueue) -> SshJobItem.SshJobStatus.INPUT
+      activeStatusQueues.contains(indepQueue) -> SshJobItem.SshJobStatus.ACTIVE
+      outputStatusQueues.contains(indepQueue) -> SshJobItem.SshJobStatus.OUTPUT
+      else -> null
+    }
   }
 
-  override suspend fun execRequest(payload: Any): Response {
-    TODO("Not yet implemented")
+  /**
+   * Parse a single job block from the SSH output into an [SshJobItem].
+   * Extracts all job fields using the =|||= delimited format.
+   * @param jobOutputParts the raw text of one job block
+   * @return the constructed [SshJobItem]
+   */
+  private fun parseSingleJob(jobOutputParts: String): SshJobItem {
+    val jobId = extractJobValue(jobOutputParts, "Job ID")
+    val jobName = extractJobValue(jobOutputParts, "Job name")
+    val jobOwner = extractJobValue(jobOutputParts, "Job owner")
+    val subsystem = extractJobValue(jobOutputParts, "Job subsystem")
+    val jobQueue = extractJobValue(jobOutputParts, "Job queue")
+    val jobStatus = getJobStatusFromQueue(jobQueue)
+    val jobTypeStr = extractJobValue(jobOutputParts, "Job type")
+    val jobType = SshJobItem.SshJobType.valueOf(jobTypeStr)
+    val jobClass = if (jobType == SshJobItem.SshJobType.STC || jobType == SshJobItem.SshJobType.TSU) jobTypeStr
+      else extractJobValue(jobOutputParts, "Job class")
+    val jobRc = extractJobValue(jobOutputParts, "Job RC").ifEmpty { null }
+    val phaseNum = extractJobValue(jobOutputParts, "Job phase \\(num\\)").toInt()
+    val phaseName = extractJobValue(jobOutputParts, "Job phase name")
+    val stepData = SshJobStepData.parseJobStepData(jobOutputParts)
+    val execData = SshJobExecData(jobOutputParts)
+    return SshJobItem(
+      jobId,
+      jobName,
+      jobOwner,
+      subsystem,
+      jobStatus,
+      jobType,
+      jobClass,
+      jobRc,
+      phaseNum,
+      phaseName,
+      stepData,
+      execData.execSystem,
+      execData.execMember,
+      execData.execSubmitted,
+      execData.execStarted,
+      execData.execEnded
+    )
   }
+
+  /**
+   * Produce the list of [SshJobItem] from the [cmdResponse].
+   * Splits the output by job markers and parses each block.
+   * Returns an empty list if the command was not successful.
+   */
+  private fun produceSshJobItems(cmdResponse: SshCmdResponse): List<SshJobItem> {
+    if (status.type != StatusType.SUCCESS) return emptyList()
+
+    // Split by the job output start marker, drop the preamble before the first job
+    val jobParts = cmdResponse.output
+      .split(Regex("""=== JOB \d+ OUTPUT START ==="""))
+      .drop(1)
+
+    return jobParts.map { parseSingleJob(it) }
+  }
+
+  override val jobs: List<SshJobItem> = produceSshJobItems(cmdResponse)
 }

--- a/src/main/kotlin/org/zowe/kotlinsdk/providers/zowe/zosmf/jes/messaging/ZosmfListJobsRequest.kt
+++ b/src/main/kotlin/org/zowe/kotlinsdk/providers/zowe/zosmf/jes/messaging/ZosmfListJobsRequest.kt
@@ -11,15 +11,26 @@
 package org.zowe.kotlinsdk.providers.zowe.zosmf.jes.messaging
 
 import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpMethod
+import io.ktor.http.isSuccess
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
 import org.zowe.kotlinsdk.core.connectivity.HttpConnection
 import org.zowe.kotlinsdk.core.jes.api.messaging.ListJobsRequest
-import org.zowe.kotlinsdk.providers.zowe.HttpRequestHeaders
 import org.zowe.kotlinsdk.providers.zowe.zosmf.ZosmfErrorReport
 import org.zowe.kotlinsdk.providers.zowe.zosmf.ZosmfHttpRequest
+import org.zowe.kotlinsdk.providers.zowe.zosmf.ZosmfStatus
+import org.zowe.kotlinsdk.providers.zowe.zosmf.jes.definitions.ZosmfJobItem
 
-// TODO: implement
-// TODO: doc
+/**
+ * @see <a href="https://www.ibm.com/docs/en/zos/3.1.0?topic=interface-list-jobs-owner-prefix-job-id">List jobs by owner, prefix, or job ID</a>
+ * @property jobPrefix the prefix query param (used when jobId is empty)
+ * @property jobId the jobid query param (mutually exclusive with prefix + owner)
+ * @property jobOwner the owner query param (used when jobId is empty)
+ * @property maxJobsToReturn the max-jobs query param
+ * @property isFetchExecData the exec-data query param
+ */
 class ZosmfListJobsRequest(
   override val connection: HttpConnection,
   override val jobPrefix: String,
@@ -27,25 +38,42 @@ class ZosmfListJobsRequest(
   override val jobOwner: String,
   override val maxJobsToReturn: Int = 1000,
   val isFetchExecData: Boolean = false,
-  override val headers: HttpRequestHeaders = TODO("Not yet implemented"),
+  override val headers: ZosmfGetJobRequestHeaders = ZosmfGetJobRequestHeaders()
 ) : ZosmfHttpRequest, ListJobsRequest {
-  override val responseClass = ZosmfGetJobResponse::class.java
+  override val responseClass = ZosmfListJobsResponse::class.java
 
   override val method = HttpMethod.Get
 
   override val body = null
 
-  override val path: String
-    get() = TODO("Not yet implemented")
+  override val path = "/zosmf/restjobs/jobs"
 
-  override val parameters: Map<String, String?>
-    get() = TODO("Not yet implemented")
+  // z/OSMF constraint: cannot combine prefix + owner with jobId in one request
+  override val parameters: Map<String, String?> = buildMap {
+    if (jobId.isNotEmpty()) {
+      put("jobid", jobId)
+    } else {
+      if (jobPrefix.isNotEmpty()) put("prefix", jobPrefix)
+      if (jobOwner.isNotEmpty()) put("owner", jobOwner)
+    }
+    if (isFetchExecData) put("exec-data", "Y")
+    if (maxJobsToReturn != 1000) put("max-jobs", maxJobsToReturn.toString())
+  }
 
+  /**
+   * Produce a [ZosmfListJobsResponse] object basing on the [clientResponse] from the HTTP request
+   * and [errorReport] if present. The response body is a JSON array of job objects.
+   */
   override suspend fun produceZosmfResponseObject(
     clientResponse: HttpResponse,
     errorReport: ZosmfErrorReport?
   ): ZosmfListJobsResponse {
-    TODO("Not yet implemented")
+    val responseSerializer = serializer<List<ZosmfJobItem>>()
+    val isRequestSucceeded = clientResponse.status.isSuccess()
+    val jobs = Json.decodeFromString(
+      responseSerializer,
+      if (isRequestSucceeded) clientResponse.bodyAsText() else "[]"
+    )
+    return ZosmfListJobsResponse(ZosmfStatus(clientResponse.status, errorReport), jobs)
   }
-
 }

--- a/src/main/kotlin/org/zowe/kotlinsdk/providers/zowe/zosmf/jes/messaging/ZosmfListJobsResponse.kt
+++ b/src/main/kotlin/org/zowe/kotlinsdk/providers/zowe/zosmf/jes/messaging/ZosmfListJobsResponse.kt
@@ -10,23 +10,16 @@
 
 package org.zowe.kotlinsdk.providers.zowe.zosmf.jes.messaging
 
-import org.zowe.kotlinsdk.core.Response
 import org.zowe.kotlinsdk.core.Status
 import org.zowe.kotlinsdk.core.jes.api.messaging.ListJobsResponse
 import org.zowe.kotlinsdk.providers.zowe.zosmf.ZosmfHttpResponse
 import org.zowe.kotlinsdk.providers.zowe.zosmf.jes.definitions.ZosmfJobItem
 
-// TODO: implement
-// TODO: doc
+/**
+ * @see <a href="https://www.ibm.com/docs/en/zos/3.1.0?topic=interface-list-jobs-owner-prefix-job-id">List jobs by owner, prefix, or job ID</a>
+ * @property jobs the actual response of the listJobs request, wrapped in this class for consistency
+ */
 class ZosmfListJobsResponse(
   override val status: Status,
-  override val jobs: List<ZosmfJobItem>,
-) : ZosmfHttpResponse(), ListJobsResponse {
-  override suspend fun produceResponseObject(clientResponse: Any): Response {
-    TODO("Not yet implemented")
-  }
-
-  override suspend fun execRequest(payload: Any): Response {
-    TODO("Not yet implemented")
-  }
-}
+  override val jobs: List<ZosmfJobItem>
+) : ZosmfHttpResponse(), ListJobsResponse


### PR DESCRIPTION
GH-28: Implement listJobs functionality for SSH and z/OSMF providers
                                          

  Summary

  - Implemented listJobs functionality for both SSH (OpenSSH) and z/OSMF providers, 
  - Added SSH job output parsing that splits multi-job output and extracts job fields (ID, name, owner, status, type, class, RC, phase, step data, exec data)
  - Implemented z/OSMF listJobs REST API integration with query parameter support for prefix, owner, jobId, max-jobs, and exec-data


  Changes

  - SshListJobsResponse — parses SSH command output into SshJobItem list with queue-to-status mapping
  - ZosmfListJobsRequest — builds GET request to /zosmf/restjobs/jobs with appropriate query params
  - ZosmfListJobsResponse — simplified to a data holder implementing ListJobsResponse
  - ListJobsResponse — I change it  to extend Response instead of Request please let me know if that was a mistake.
  
  There is one test failing but I think it may be a data error.   In SshListJobsTestSpec                                                                                                   The assertion expects "TESTJI1" but the mock data sets the owner to "TESTJO1". Other than that all the tests passed and I ran the realLifeTests file with my Z-Explore credentials and those worked as well. 